### PR TITLE
Update test-console-log-with-jest.md

### DIFF
--- a/entries/test-console-log-with-jest.md
+++ b/entries/test-console-log-with-jest.md
@@ -19,6 +19,7 @@ I need to test with my code logged something.
 
 // create a function into global context for Jest
 global.console = {
+  ...console,
   log: jest.fn(),
   info: jest.fn(),
   error: jest.fn()


### PR DESCRIPTION
Spread console into mock.
Typescript complains about this, this also allows you to retain console functionality outside what you're testing.